### PR TITLE
add keyword static for function as function is called statically

### DIFF
--- a/src/Client/ErrorHandlerMiddleware.php
+++ b/src/Client/ErrorHandlerMiddleware.php
@@ -66,7 +66,7 @@ abstract class ErrorHandlerMiddleware
         throw $exception;
     }
 
-    protected function createExceptionFromStatusCode(
+    protected static function createExceptionFromStatusCode(
         string $errorName,
         ResponseInterface $response,
         int $statusCode


### PR DESCRIPTION
The function `createExceptionFromStatusCode` is called statically in lines  58 and 63.
In php < 8 this was not a problem. But in php 8+ this is throwing an exception.